### PR TITLE
Provide initial Docker support

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -50,7 +50,10 @@ other isolated to prevent access to the database server. If you have any
 child services that require access to the database, they should be attached to
 the backend network as well.
 
-You will need to download the [database schema file](https://github.com/SteamDatabase/steamdb.info/blob/master/Database.sql)
+You will need to create a valid `settings.json` file and place it alongside
+the `docker-compose.yml` file - see `settings.json.default` for a sample.
+
+You will also need to download the [database schema file](https://github.com/SteamDatabase/steamdb.info/blob/master/Database.sql)
 from the main repository and place it alongside the `docker-compose.yml` file
 to initialise the database. One thing to be aware of when first starting the
 stack is that the database will take some time to setup on first run, so you

--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,64 @@
+# Running SteamDatabaseBackend in Docker
+First, you will need to clone this repository to your local environment:
+
+`$ git clone https://github.com/SteamDatabase/SteamDatabaseBackend`
+
+Then run the following to build an image:
+
+`$ docker build -t steamdb-backend .`
+
+Once that's done, you need a MySQL/MariaDB database configured for use by this
+image. The easiest way to do that is by using [docker-compose](https://docs.docker.com/compose/),
+with a `docker-compose.yml` like the following:
+
+```yaml
+version: "3"
+
+services:
+  backend:
+    image: steamdb-backend
+    volumes:
+      - "./settings.json:/app/settings.json:ro"
+      - "./files:/app/files"
+    networks:
+      - frontend
+      - backend
+    depends_on:
+      - db
+
+  db:
+    image: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: "replacemereplacemereplaceme"
+      MYSQL_DATABASE: "steamcachedb"
+      MYSQL_USER: "steamcachedb"
+      MYSQL_PASSWORD: "replacemereplacemereplaceme"
+    volumes:
+      - "./db:/var/lib/mysql"
+      - "./Database.sql:/docker-entrypoint-initdb.d/init.sql"
+    networks:
+      - backend
+
+networks:
+  frontend:
+  backend:
+    internal: true
+```
+
+This compose file provides two networks, one with internet access, and the
+other isolated to prevent access to the database server. If you have any
+child services that require access to the database, they should be attached to
+the backend network as well.
+
+You will need to download the [database schema file](https://github.com/SteamDatabase/steamdb.info/blob/master/Database.sql)
+from the main repository and place it alongside the `docker-compose.yml` file
+to initialise the database. One thing to be aware of when first starting the
+stack is that the database will take some time to setup on first run, so you
+will need to restart the backend after the database is ready. Alternatively,
+when starting for the first time, invoke `docker-compose` as follows:
+
+```
+$ docker-compose up -d db
+$ sleep 2m
+$ docker-compose up -d backend
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM mono:4
+
+RUN \
+	apt-get update \
+	&& apt-get install -y git \
+	&& rm -rf /var/cache/apt/* /var/lib/apt/lists/* \
+	&& mkdir -p /app/src/
+
+COPY . /app/src/
+
+RUN \
+	/app/src/build.sh \
+	&& mv /app/src/bin/Release/ /app-2/ \
+	&& rm -rf /app \
+	&& mv /app-2 /app
+
+CMD ["bash", "-c", "sleep 5; mono /app/SteamDatabaseBackend.exe"]


### PR DESCRIPTION
This provides a `Dockerfile` and initial usage documentation to run the SteamDatabaseBackend in a Docker container. This simplifies the initial setup and makes it simpler for someone to spin up their own instance.

As a use-case example, when running a local [steamcache](https://github.com/steamcache/steamcache) instance, the access logs will contain in the URL the depot ID being requested by a client. By being able to resolve these to depot names, and resolve a depot ID to an AppID, the cache maintainer can better manage content and shout at people at LAN parties downloading single player games.